### PR TITLE
Add BenchmarkDotNet Benchmarks

### DIFF
--- a/src/Cistern.Linq.Benchmarking/Benchmarks/AverageBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/AverageBenchmark.cs
@@ -1,0 +1,42 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class AverageBenchmark : NumericBenchmarkBase
+	{
+		[Benchmark]
+		public double ForLoop()
+		{
+			var count = 0;
+			double sum = 0;
+			foreach (var n in Numbers)
+			{
+				sum += n;
+				count++;
+			}
+			
+			if (count == 0)
+			{
+				throw new InvalidOperationException("Sequence contains no elements");
+			}
+
+			return sum / count;
+		}
+
+		[Benchmark(Baseline = true)]
+		public double SystemLinq()
+		{
+			return System.Linq.Enumerable.Average(Numbers);
+		}
+		
+		[Benchmark]
+		public double CisternLinq()
+		{
+			return Enumerable.Average(Numbers);
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/ConcatBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/ConcatBenchmark.cs
@@ -1,0 +1,66 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class ConcatBenchmark
+	{
+		[Params(10, 100, 1000)]
+		public int NumberOfConcats;
+
+		public byte[][] DataToConcat;
+
+		public const int ArraySize = 10;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			DataToConcat = new byte[NumberOfConcats][];
+			
+			for (int i = 0; i < NumberOfConcats; i++)
+			{
+				DataToConcat[i] = new byte[ArraySize];
+			}
+		}
+
+		[Benchmark]
+		public byte[] ForLoop()
+		{
+			var items = new List<byte>();
+			
+			foreach (var array in DataToConcat)
+			{
+				items.AddRange(array);
+			}
+			
+			return items.ToArray();
+		}
+
+		[Benchmark(Baseline = true)]
+		public byte[] SystemLinq()
+		{
+			var enumerable = (IEnumerable<byte>)new byte[0];
+			foreach (var array in DataToConcat)
+			{
+				enumerable = System.Linq.Enumerable.Concat(enumerable, array);
+			}
+
+			return System.Linq.Enumerable.ToArray(enumerable);
+		}
+		
+		[Benchmark]
+		public byte[] CisternLinq()
+		{
+			var enumerable = (IEnumerable<byte>)new byte[0];
+			foreach (var array in DataToConcat)
+			{
+				enumerable = Enumerable.Concat(enumerable, array);
+			}
+
+			return Enumerable.ToArray(enumerable);
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/MaxBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/MaxBenchmark.cs
@@ -22,7 +22,7 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 			
 			if (!max.HasValue)
 			{
-				throw new InvalidOperationException("Sequence has no elements!");
+				throw new InvalidOperationException("Sequence contains no elements");
 			}
 			
 			return max.Value;

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/MaxBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/MaxBenchmark.cs
@@ -1,0 +1,43 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class MaxBenchmark : NumericBenchmarkBase
+	{
+		[Benchmark]
+		public double ForLoop()
+		{
+			double? max = 0;
+			foreach (var n in Numbers)
+			{
+				if (n > max || max == null)
+				{
+					max = n;
+				}
+			}
+			
+			if (!max.HasValue)
+			{
+				throw new InvalidOperationException("Sequence has no elements!");
+			}
+			
+			return max.Value;
+		}
+
+		[Benchmark(Baseline = true)]
+		public double SystemLinq()
+		{
+			return System.Linq.Enumerable.Max(Numbers);
+		}
+		
+		[Benchmark]
+		public double CisternLinq()
+		{
+			return Enumerable.Max(Numbers);
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/MinBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/MinBenchmark.cs
@@ -22,7 +22,7 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 			
 			if (!min.HasValue)
 			{
-				throw new InvalidOperationException("Sequence has no elements!");
+				throw new InvalidOperationException("Sequence contains no elements");
 			}
 			
 			return min.Value;

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/MinBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/MinBenchmark.cs
@@ -1,0 +1,43 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class MinBenchmark : NumericBenchmarkBase
+	{
+		[Benchmark]
+		public double ForLoop()
+		{
+			double? min = 0;
+			foreach (var n in Numbers)
+			{
+				if (n < min || min == null)
+				{
+					min = n;
+				}
+			}
+			
+			if (!min.HasValue)
+			{
+				throw new InvalidOperationException("Sequence has no elements!");
+			}
+			
+			return min.Value;
+		}
+
+		[Benchmark(Baseline = true)]
+		public double SystemLinq()
+		{
+			return System.Linq.Enumerable.Min(Numbers);
+		}
+		
+		[Benchmark]
+		public double CisternLinq()
+		{
+			return Enumerable.Min(Numbers);
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/NumericBenchmarkBase.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/NumericBenchmarkBase.cs
@@ -8,7 +8,7 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 	public abstract class NumericBenchmarkBase
 	{
 
-		[Params(1000, 1000000)]
+		[Params(10, 1000, 1000000)]
 		public int NumberOfItems;
 
 		public double[] Numbers;

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/NumericBenchmarkBase.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/NumericBenchmarkBase.cs
@@ -1,0 +1,26 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	public abstract class NumericBenchmarkBase
+	{
+
+		[Params(1000, 1000000)]
+		public int NumberOfItems;
+
+		public double[] Numbers;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			Numbers = new double[NumberOfItems];
+			for (int i = 0; i < NumberOfItems; i++)
+			{
+				Numbers[i] = i + 1;
+			}
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/OrderByAscendingBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/OrderByAscendingBenchmark.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class OrderByAscendingBenchmark : NumericBenchmarkBase
+	{
+		[Benchmark(Baseline = true)]
+		public double[] SystemLinq()
+		{
+			return System.Linq.Enumerable.ToArray(System.Linq.Enumerable.OrderBy(Numbers, n => n));
+		}
+		
+		[Benchmark]
+		public double[] CisternLinq()
+		{
+			return Enumerable.ToArray(Enumerable.OrderBy(Numbers, n => n));
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/OrderByDescendingBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/OrderByDescendingBenchmark.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class OrderByDescendingBenchmark : NumericBenchmarkBase
+	{
+		[Benchmark(Baseline = true)]
+		public double[] SystemLinq()
+		{
+			return System.Linq.Enumerable.ToArray(System.Linq.Enumerable.OrderByDescending(Numbers, n => n));
+		}
+		
+		[Benchmark]
+		public double[] CisternLinq()
+		{
+			return Enumerable.ToArray(Enumerable.OrderByDescending(Numbers, n => n));
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/SelectBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/SelectBenchmark.cs
@@ -1,0 +1,44 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class SelectBenchmark : NumericBenchmarkBase
+	{
+		[Benchmark]
+		public double[] ForLoop()
+		{
+			var items = new double[NumberOfItems];
+			foreach (var n in Numbers)
+			{
+				items[(int)n - 1] = n + 1;
+			}
+			return items;
+		}
+
+		[Benchmark(Baseline = true)]
+		public double[] SystemLinq()
+		{
+			var items = new double[NumberOfItems];
+			foreach (var item in System.Linq.Enumerable.Select(Numbers, n => n + 1))
+			{
+				items[(int)item - 2] = item;
+			}
+			return items;
+		}
+		
+		[Benchmark]
+		public double[] CisternLinq()
+		{
+			var items = new double[NumberOfItems];
+			foreach (var item in Enumerable.Select(Numbers, n => n + 1))
+			{
+				items[(int)item - 2] = item;
+			}
+			return items;
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/SkipBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/SkipBenchmark.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class SkipBenchmark : NumericBenchmarkBase
+	{
+		[Benchmark(Baseline = true)]
+		public double[] SystemLinq()
+		{
+			return System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Skip(Numbers, NumberOfItems - 1));
+		}
+		
+		[Benchmark]
+		public double[] CisternLinq()
+		{
+			return Enumerable.ToArray(Enumerable.Skip(Numbers, NumberOfItems - 1));
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/SumBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/SumBenchmark.cs
@@ -6,24 +6,8 @@ using System.Text;
 namespace Cistern.Linq.Benchmarking.Benchmarks
 {
 	[CoreJob, MemoryDiagnoser]
-	public class SumBenchmark
+	public class SumBenchmark : NumericBenchmarkBase
 	{
-		[Params(1000, 1000000)]
-		public int NumberOfItems;
-
-		public double[] Numbers;
-
-		[GlobalSetup]
-		public void Setup()
-		{
-			Numbers = new double[NumberOfItems];
-			for (int i = 0; i < NumberOfItems; i++)
-			{
-				Numbers[i] = i;
-			}
-		}
-
-
 		[Benchmark]
 		public double ForLoop()
 		{

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/SumBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/SumBenchmark.cs
@@ -47,13 +47,13 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 		}
 
 		[Benchmark(Baseline = true)]
-		public double SystemLinqSum()
+		public double SystemLinq()
 		{
 			return System.Linq.Enumerable.Sum(Numbers);
 		}
 		
 		[Benchmark]
-		public double CisternLinqSum()
+		public double CisternLinq()
 		{
 			return Enumerable.Sum(Numbers);
 		}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/SumBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/SumBenchmark.cs
@@ -8,7 +8,7 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 	[CoreJob, MemoryDiagnoser]
 	public class SumBenchmark
 	{
-		[Params(1000, 10000, 20000)]
+		[Params(1000, 1000000)]
 		public int NumberOfItems;
 
 		public double[] Numbers;
@@ -23,16 +23,25 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 			}
 		}
 
+
 		[Benchmark]
 		public double ForLoop()
 		{
 			double sum = 0;
+			for (int i = 0; i < NumberOfItems; i++)
+			{
+				sum += Numbers[i];
+			}
+			return sum;
+		}
+
+		[Benchmark]
+		public double ForEachLoop()
+		{
+			double sum = 0;
 			foreach (var n in Numbers)
 			{
-				if (n >= 5.0)
-				{
-					sum += n;
-				}
+				sum += n;
 			}
 			return sum;
 		}
@@ -40,13 +49,13 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 		[Benchmark(Baseline = true)]
 		public double SystemLinqSum()
 		{
-			return System.Linq.Enumerable.Sum(System.Linq.Enumerable.Where(Numbers, n => n >= 5.0));
+			return System.Linq.Enumerable.Sum(Numbers);
 		}
 		
-		[Benchmark()]
+		[Benchmark]
 		public double CisternLinqSum()
 		{
-			return Enumerable.Sum(Enumerable.Where(Numbers, n => n >= 5.0));
+			return Enumerable.Sum(Numbers);
 		}
 	}
 }

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/SumBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/SumBenchmark.cs
@@ -1,0 +1,52 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class SumBenchmark
+	{
+		[Params(1000, 10000, 20000)]
+		public int NumberOfItems;
+
+		public double[] Numbers;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			Numbers = new double[NumberOfItems];
+			for (int i = 0; i < NumberOfItems; i++)
+			{
+				Numbers[i] = i;
+			}
+		}
+
+		[Benchmark]
+		public double ForLoop()
+		{
+			double sum = 0;
+			foreach (var n in Numbers)
+			{
+				if (n >= 5.0)
+				{
+					sum += n;
+				}
+			}
+			return sum;
+		}
+
+		[Benchmark(Baseline = true)]
+		public double SystemLinqSum()
+		{
+			return System.Linq.Enumerable.Sum(System.Linq.Enumerable.Where(Numbers, n => n >= 5.0));
+		}
+		
+		[Benchmark()]
+		public double CisternLinqSum()
+		{
+			return Enumerable.Sum(Enumerable.Where(Numbers, n => n >= 5.0));
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/SumBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/SumBenchmark.cs
@@ -12,17 +12,6 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 		public double ForLoop()
 		{
 			double sum = 0;
-			for (int i = 0; i < NumberOfItems; i++)
-			{
-				sum += Numbers[i];
-			}
-			return sum;
-		}
-
-		[Benchmark]
-		public double ForEachLoop()
-		{
-			double sum = 0;
 			foreach (var n in Numbers)
 			{
 				sum += n;

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/TakeBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/TakeBenchmark.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class TakeBenchmark : NumericBenchmarkBase
+	{
+		[Benchmark(Baseline = true)]
+		public double[] SystemLinq()
+		{
+			return System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Take(Numbers, NumberOfItems / 2));
+		}
+		
+		[Benchmark]
+		public double[] CisternLinq()
+		{
+			return Enumerable.ToArray(Enumerable.Take(Numbers, NumberOfItems / 2));
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/ToDictionaryBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/ToDictionaryBenchmark.cs
@@ -1,0 +1,36 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class ToDictionaryBenchmark : NumericBenchmarkBase
+	{
+		[Benchmark]
+		public Dictionary<double, double> ForLoop()
+		{
+			var result = new Dictionary<double, double>(NumberOfItems);
+			
+			foreach (var n in Numbers)
+			{
+				result.Add(n, n);
+			}
+
+			return result;
+		}
+		
+		[Benchmark(Baseline = true)]
+		public Dictionary<double, double> SystemLinq()
+		{
+			return System.Linq.Enumerable.ToDictionary(Numbers, n => n);
+		}
+		
+		[Benchmark]
+		public Dictionary<double, double> CisternLinq()
+		{
+			return Enumerable.ToDictionary(Numbers, n => n);
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/ToListBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/ToListBenchmark.cs
@@ -1,0 +1,57 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class ToListBenchmark
+	{
+		[Params(10000, 1000000)]
+		public int NumberOfItems;
+
+		public double[] Numbers;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			Numbers = new double[NumberOfItems];
+			for (int i = 0; i < NumberOfItems; i++)
+			{
+				Numbers[i] = i + 1;
+			}
+		}
+
+		[Benchmark]
+		public List<double> ForLoop()
+		{
+			var list = new List<double>();
+			
+			foreach (var n in Numbers)
+			{
+				list.Add(n);
+			}
+
+			return list;
+		}
+		
+		[Benchmark]
+		public List<double> Constructor()
+		{
+			return new List<double>(Numbers);
+		}
+
+		[Benchmark(Baseline = true)]
+		public List<double> SystemLinq()
+		{
+			return System.Linq.Enumerable.ToList(Numbers);
+		}
+		
+		[Benchmark]
+		public List<double> CisternLinq()
+		{
+			return Enumerable.ToList(Numbers);
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/ToListBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/ToListBenchmark.cs
@@ -6,23 +6,8 @@ using System.Text;
 namespace Cistern.Linq.Benchmarking.Benchmarks
 {
 	[CoreJob, MemoryDiagnoser]
-	public class ToListBenchmark
+	public class ToListBenchmark : NumericBenchmarkBase
 	{
-		[Params(10000, 1000000)]
-		public int NumberOfItems;
-
-		public double[] Numbers;
-
-		[GlobalSetup]
-		public void Setup()
-		{
-			Numbers = new double[NumberOfItems];
-			for (int i = 0; i < NumberOfItems; i++)
-			{
-				Numbers[i] = i + 1;
-			}
-		}
-
 		[Benchmark]
 		public List<double> ForLoop()
 		{

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/ToListBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/ToListBenchmark.cs
@@ -11,7 +11,7 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 		[Benchmark]
 		public List<double> ForLoop()
 		{
-			var list = new List<double>();
+			var list = new List<double>(NumberOfItems);
 			
 			foreach (var n in Numbers)
 			{
@@ -19,12 +19,6 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 			}
 
 			return list;
-		}
-		
-		[Benchmark]
-		public List<double> Constructor()
-		{
-			return new List<double>(Numbers);
 		}
 
 		[Benchmark(Baseline = true)]

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/WhereBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/WhereBenchmark.cs
@@ -25,13 +25,23 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 		[Benchmark(Baseline = true)]
 		public double SystemLinq()
 		{
-			return System.Linq.Enumerable.First(System.Linq.Enumerable.Where(Numbers, n => n == NumberOfItems));
+			foreach (var item in System.Linq.Enumerable.Where(Numbers, n => n == NumberOfItems))
+			{
+				return item;
+			}
+
+			throw new Exception("Not found!");
 		}
 		
 		[Benchmark]
 		public double CisternLinq()
 		{
-			return Enumerable.First(Enumerable.Where(Numbers, n => n == NumberOfItems));
+			foreach (var item in Enumerable.Where(Numbers, n => n == NumberOfItems))
+			{
+				return item;
+			}
+
+			throw new Exception("Not found!");
 		}
 	}
 }

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/WhereBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/WhereBenchmark.cs
@@ -38,13 +38,13 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 		}
 
 		[Benchmark(Baseline = true)]
-		public double SystemLinqSum()
+		public double SystemLinq()
 		{
 			return System.Linq.Enumerable.First(System.Linq.Enumerable.Where(Numbers, n => n == NumberOfItems));
 		}
 		
 		[Benchmark()]
-		public double CisternLinqSum()
+		public double CisternLinq()
 		{
 			return Enumerable.First(Enumerable.Where(Numbers, n => n == NumberOfItems));
 		}

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/WhereBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/WhereBenchmark.cs
@@ -6,23 +6,8 @@ using System.Text;
 namespace Cistern.Linq.Benchmarking.Benchmarks
 {
 	[CoreJob, MemoryDiagnoser]
-	public class WhereBenchmark
+	public class WhereBenchmark : NumericBenchmarkBase
 	{
-		[Params(10000, 1000000)]
-		public int NumberOfItems;
-
-		public double[] Numbers;
-
-		[GlobalSetup]
-		public void Setup()
-		{
-			Numbers = new double[NumberOfItems];
-			for (int i = 0; i < NumberOfItems; i++)
-			{
-				Numbers[i] = i + 1;
-			}
-		}
-
 		[Benchmark]
 		public double ForLoop()
 		{
@@ -43,7 +28,7 @@ namespace Cistern.Linq.Benchmarking.Benchmarks
 			return System.Linq.Enumerable.First(System.Linq.Enumerable.Where(Numbers, n => n == NumberOfItems));
 		}
 		
-		[Benchmark()]
+		[Benchmark]
 		public double CisternLinq()
 		{
 			return Enumerable.First(Enumerable.Where(Numbers, n => n == NumberOfItems));

--- a/src/Cistern.Linq.Benchmarking/Benchmarks/WhereBenchmark.cs
+++ b/src/Cistern.Linq.Benchmarking/Benchmarks/WhereBenchmark.cs
@@ -1,0 +1,52 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cistern.Linq.Benchmarking.Benchmarks
+{
+	[CoreJob, MemoryDiagnoser]
+	public class WhereBenchmark
+	{
+		[Params(10000, 1000000)]
+		public int NumberOfItems;
+
+		public double[] Numbers;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			Numbers = new double[NumberOfItems];
+			for (int i = 0; i < NumberOfItems; i++)
+			{
+				Numbers[i] = i + 1;
+			}
+		}
+
+		[Benchmark]
+		public double ForLoop()
+		{
+			foreach (var n in Numbers)
+			{
+				if (n == NumberOfItems)
+				{
+					return n;
+				}
+			}
+
+			throw new Exception("Not found!");
+		}
+
+		[Benchmark(Baseline = true)]
+		public double SystemLinqSum()
+		{
+			return System.Linq.Enumerable.First(System.Linq.Enumerable.Where(Numbers, n => n == NumberOfItems));
+		}
+		
+		[Benchmark()]
+		public double CisternLinqSum()
+		{
+			return Enumerable.First(Enumerable.Where(Numbers, n => n == NumberOfItems));
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Cistern.Linq.Benchmarking.csproj
+++ b/src/Cistern.Linq.Benchmarking/Cistern.Linq.Benchmarking.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Cistern.Linq\Cistern.Linq.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Cistern.Linq.Benchmarking/Program.cs
+++ b/src/Cistern.Linq.Benchmarking/Program.cs
@@ -1,0 +1,14 @@
+﻿using BenchmarkDotNet.Running;
+using Cistern.Linq.Benchmarking.Benchmarks;
+using System;
+
+namespace Cistern.Linq.Benchmarking
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			BenchmarkRunner.Run<SumBenchmark>();
+		}
+	}
+}

--- a/src/Cistern.Linq.Benchmarking/Program.cs
+++ b/src/Cistern.Linq.Benchmarking/Program.cs
@@ -8,7 +8,7 @@ namespace Cistern.Linq.Benchmarking
 	{
 		static void Main(string[] args)
 		{
-			BenchmarkRunner.Run<SumBenchmark>();
+			BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 		}
 	}
 }

--- a/src/Cistern.Linq.sln
+++ b/src/Cistern.Linq.sln
@@ -15,6 +15,8 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Cistern.Linq.Playground.FSh
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cistern.Linq.Playground.CSharp", "Cistern.Linq.Playground.CSharp\Cistern.Linq.Playground.CSharp.csproj", "{3839E702-D1E7-4713-8525-ADCF83E27543}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cistern.Linq.Benchmarking", "Cistern.Linq.Benchmarking\Cistern.Linq.Benchmarking.csproj", "{BC0CEC74-94C7-4809-A826-2D60B7AE3CF9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{3839E702-D1E7-4713-8525-ADCF83E27543}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3839E702-D1E7-4713-8525-ADCF83E27543}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3839E702-D1E7-4713-8525-ADCF83E27543}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC0CEC74-94C7-4809-A826-2D60B7AE3CF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC0CEC74-94C7-4809-A826-2D60B7AE3CF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC0CEC74-94C7-4809-A826-2D60B7AE3CF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC0CEC74-94C7-4809-A826-2D60B7AE3CF9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This starts addressing #2 by adding BenchmarkDotNet to a new project with various LINQ benchmarks.

Currently:
- Sum (faster)
- Where (slower)
- Skip (slower)
- Take (slower)
- ToList (same)
- ToDictionary (6% - 10% slower)
- OrderBy (6% - 10% slower, twice the allocations - note: this test, the data is already ascending)
- OrderByDescending (15% - 18% slower, twice the allocations - note: this test, the data is ascending)
- Min (~55% faster)
- Max (~85% faster - even faster than a ForLoop)
- Average (~40% faster)
- Select (0% - 17% faster)
- Concat (45% - ~7000% slower - falls down quite far for large number of concats)