### PR TITLE
Fixes EnumerableDebugView tests

### DIFF
--- a/src/Cistern.Linq.Tests/EnumerableDebugViewTests.cs
+++ b/src/Cistern.Linq.Tests/EnumerableDebugViewTests.cs
@@ -31,7 +31,7 @@ namespace Cistern.Linq.Tests
             object debugView = CreateSystemCore_EnumerableDebugView(source);
             Exception exc = Assert.Throws<TargetInvocationException>(() => GetItems<object>(debugView));
             Assert.NotNull(exc.InnerException);
-            Assert.Equal("System.Linq.SystemCore_EnumerableDebugViewEmptyException", exc.InnerException.GetType().FullName);
+            Assert.Equal("Cistern.Linq.SystemCore_EnumerableDebugViewEmptyException", exc.InnerException.GetType().FullName);
             Assert.False(string.IsNullOrEmpty(GetEmptyProperty(exc.InnerException)));
         }
 
@@ -58,7 +58,7 @@ namespace Cistern.Linq.Tests
             object debugView = CreateSystemCore_EnumerableDebugView(source);
             Exception exc = Assert.Throws<TargetInvocationException>(() => GetItems<int>(debugView));
             Assert.NotNull(exc.InnerException);
-            Assert.Equal("System.Linq.SystemCore_EnumerableDebugViewEmptyException", exc.InnerException.GetType().FullName);
+            Assert.Equal("Cistern.Linq.SystemCore_EnumerableDebugViewEmptyException", exc.InnerException.GetType().FullName);
             Assert.False(string.IsNullOrEmpty(GetEmptyProperty(exc.InnerException)));
         }
 
@@ -72,14 +72,14 @@ namespace Cistern.Linq.Tests
 
         private static object CreateSystemCore_EnumerableDebugView(IEnumerable source)
         {
-            Type edvType = typeof(Enumerable).GetTypeInfo().Assembly.GetType("System.Linq.SystemCore_EnumerableDebugView");
+            Type edvType = typeof(Enumerable).GetTypeInfo().Assembly.GetType("Cistern.Linq.SystemCore_EnumerableDebugView");
             ConstructorInfo ctor = edvType.GetTypeInfo().DeclaredConstructors.First();
             return ctor.Invoke(new object[] { source });
         }
 
         private static object CreateSystemCore_EnumerableDebugView<T>(IEnumerable<T> source)
         {
-            Type edvOpenGenericType = typeof(Enumerable).GetTypeInfo().Assembly.GetType("System.Linq.SystemCore_EnumerableDebugView`1");
+            Type edvOpenGenericType = typeof(Enumerable).GetTypeInfo().Assembly.GetType("Cistern.Linq.SystemCore_EnumerableDebugView`1");
             Type edvClosedGenericType = edvOpenGenericType.MakeGenericType(typeof(T));
             ConstructorInfo ctor = edvClosedGenericType.GetTypeInfo().DeclaredConstructors.First();
             return ctor.Invoke(new object[] { source });


### PR DESCRIPTION
Cistern classes don't appear under `System.Linq`, these tests needed to be updated to reflect that.
Obviously if the library gets re-merged back into corefx, this would need to be updated.

I wanted to use `nameof(ClassNameHere)` (thus allowing an easy refactor later) however unfortunately some of these classes are internal and can't be referenced like that from the test project.